### PR TITLE
Use the raw GitHub URL when installing with kubectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Read the [annoucement here][3].
 
 1. Deploy Cruise to your cluster
     ```
-    % kubectl apply -f https://github.com/heptiolabs/cruise/blob/master/deployment/cruise.yaml
+    % kubectl apply -f https://raw.githubusercontent.com/heptiolabs/cruise/master/deployment/cruise.yaml
     ```
 2. Configure your Pingdom API credentials
     ```


### PR DESCRIPTION
Pretty self-explanatory. Unless there's some `kubectl` magic I'm unaware of, we should be using the raw file on GitHub and not the HTML page.